### PR TITLE
terraform code upgraded to 0.12 with modified test cases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
       event: push
 
   run-testrunner-tests:
-    image: quay.io/ukhomeofficedigital/tf-testrunner
+    image: quay.io/ukhomeofficedigital/tf-testrunner:32
     commands: python -m unittest tests/*_test.py
     secrets:
       - AWS_ACCESS_KEY_ID

--- a/main.tf
+++ b/main.tf
@@ -59,4 +59,3 @@ resource "aws_security_group" "sgrp" {
     Name = "sg-${local.naming_suffix}"
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -3,48 +3,48 @@ locals {
 }
 
 resource "aws_subnet" "lambda_subnet" {
-  vpc_id                  = "${var.appsvpc_id}"
-  cidr_block              = "${var.dq_lambda_subnet_cidr}"
+  vpc_id                  = var.appsvpc_id
+  cidr_block              = var.dq_lambda_subnet_cidr
   map_public_ip_on_launch = false
-  availability_zone       = "${var.az}"
+  availability_zone       = var.az
 
-  tags {
+  tags = {
     Name = "subnet-${local.naming_suffix}"
   }
 }
 
 resource "aws_subnet" "lambda_subnet_az2" {
-  vpc_id                  = "${var.appsvpc_id}"
-  cidr_block              = "${var.dq_lambda_subnet_cidr_az2}"
+  vpc_id                  = var.appsvpc_id
+  cidr_block              = var.dq_lambda_subnet_cidr_az2
   map_public_ip_on_launch = false
-  availability_zone       = "${var.az2}"
+  availability_zone       = var.az2
 
-  tags {
+  tags = {
     Name = "az2-subnet-${local.naming_suffix}"
   }
 }
 
 resource "aws_route_table_association" "internal_tableau_rt_association" {
-  subnet_id      = "${aws_subnet.lambda_subnet.id}"
-  route_table_id = "${var.route_table_id}"
+  subnet_id      = aws_subnet.lambda_subnet.id
+  route_table_id = var.route_table_id
 }
 
 resource "aws_route_table_association" "internal_tableau_rt_association_az2" {
-  subnet_id      = "${aws_subnet.lambda_subnet_az2.id}"
-  route_table_id = "${var.route_table_id}"
+  subnet_id      = aws_subnet.lambda_subnet_az2.id
+  route_table_id = var.route_table_id
 }
 
 resource "aws_security_group" "sgrp" {
-  vpc_id = "${var.appsvpc_id}"
+  vpc_id = var.appsvpc_id
 
   ingress {
-    from_port = "${var.rds_from_port}"
-    to_port   = "${var.rds_to_port}"
-    protocol  = "${var.rds_protocol}"
+    from_port = var.rds_from_port
+    to_port   = var.rds_to_port
+    protocol  = var.rds_protocol
 
     cidr_blocks = [
-      "${var.dq_lambda_subnet_cidr}",
-      "${var.dq_lambda_subnet_cidr_az2}",
+      var.dq_lambda_subnet_cidr,
+      var.dq_lambda_subnet_cidr_az2,
     ]
   }
 
@@ -55,7 +55,8 @@ resource "aws_security_group" "sgrp" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "sg-${local.naming_suffix}"
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,12 @@
 output "lambda_subnet" {
-  value = "${aws_subnet.lambda_subnet.id}"
+  value = aws_subnet.lambda_subnet.id
 }
 
 output "lambda_subnet_az2" {
-  value = "${aws_subnet.lambda_subnet_az2.id}"
+  value = aws_subnet.lambda_subnet_az2.id
 }
 
 output "lambda_sgrp" {
-  value = "${aws_security_group.sgrp.id}"
+  value = aws_security_group.sgrp.id
 }
+

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -26,20 +26,21 @@ class TestE2E(unittest.TestCase):
             }
 
         """
-        self.result = Runner(self.snippet).result
+        self.runner = Runner(self.snippet)
+        self.result = self.runner.result
 
 
     def test_subnet_vpc(self):
-        self.assertEqual(self.result["root_modules"]["aws_subnet.lambda_subnet"]["vpc_id"], "1234")
+        self.assertEqual(self.runner.get_value("module.root_modules.aws_subnet.lambda_subnet", "vpc_id"), "1234")
 
     def test_subnet_cidr(self):
-        self.assertEqual(self.result["root_modules"]["aws_subnet.lambda_subnet"]["cidr_block"], "10.1.42.0/24")
+        self.assertEqual(self.runner.get_value("module.root_modules.aws_subnet.lambda_subnet", "cidr_block"), "10.1.42.0/24")
 
     def test_subnet_tags(self):
-        self.assertEqual(self.result["root_modules"]["aws_subnet.lambda_subnet"]["tags.Name"], "subnet-lambda-apps-preprod-dq")
+        self.assertEqual(self.runner.get_value("module.root_modules.aws_subnet.lambda_subnet", "tags"), {'Name': "subnet-lambda-apps-preprod-dq"})
 
     def test_security_group_tags(self):
-        self.assertEqual(self.result["root_modules"]["aws_security_group.sgrp"]["tags.Name"], "sg-lambda-apps-preprod-dq")
+        self.assertEqual(self.runner.get_value("module.root_modules.aws_security_group.sgrp", "tags"), {'Name': "sg-lambda-apps-preprod-dq"})
 
 if __name__ == '__main__':
     unittest.main()

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,5 @@
-variable "appsvpc_id" {}
+variable "appsvpc_id" {
+}
 
 variable "naming_suffix" {
   default     = false
@@ -49,3 +50,4 @@ variable "az2" {
   default     = "eu-west-2b"
   description = "Default availability zone for the subnet."
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
What changes does this PR bring?

terraform 12 upgrade

What are the relevant tickets?

YEL-3182

Are tests included? (if applicable)

Infra is already plan and tested in TEST account

What if you don’t make a change?

terraform 12 has been out since 2 years ago. It has made change to HCL 2 and code support more functionalities with bug fixes.